### PR TITLE
Fix environment variable loading before imports

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,10 @@
+from dotenv import load_dotenv
+
+# .env 파일을 먼저 로드하여 이후 모듈들이 환경변수를 사용할 수 있도록 한다.
+load_dotenv()
+
 from utils.file_utils import find_target_excel_file, convert_xls_to_xlsx, create_meal_expense_file
 from utils.overtime_utils import check_overtime_pay, overtimeCnt, officialDataMaker
-from dotenv import load_dotenv
 
 
 def find_and_convert_excel(keyword):
@@ -32,7 +36,6 @@ def generate_official_data(monthly_xlsx, count_data):
 
 
 def main():
-    load_dotenv()
     print("초과근무승인 파일 처리를 시작합니다.")
 
     # 1. 초과근무승인 파일 찾기 → 변환

--- a/src/utils/overtime_utils.py
+++ b/src/utils/overtime_utils.py
@@ -19,7 +19,7 @@ try:
     MEAL_FEE = int(os.getenv("MEAL_FEE", 5500))
 except ValueError:
     raise EnvironmentError(
-        f"환경변수 'MEAL_FEE'는 정수여야 합니다. 제공된 값: '{os.getenv("MEAL_FEE")}'")
+        f"환경변수 'MEAL_FEE'는 정수여야 합니다. 제공된 값: '{os.getenv('MEAL_FEE')}'")
 
 OFFICIAL_DATA_NAMES_STR = os.getenv("OFFICIAL_DATA_NAMES_STR", "")
 OFFICIAL_DATA_NAMES = [


### PR DESCRIPTION
## Summary
- load `.env` before importing modules that rely on it
- fix invalid f-string quoting in `overtime_utils`

## Testing
- `python -m py_compile src/main.py src/utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683fe357259083298e080472ddc74d96