### PR TITLE
chore: add github-actions ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary
- Add `github-actions` package ecosystem to dependabot configuration
- Enables automated version update PRs for GitHub Actions dependencies
- Minor and patch updates are grouped together to reduce PR noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)